### PR TITLE
Configure GitHub Action based CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: Lint
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    container:
+      image: registry.gitlab.com/jameshiew/toolbox/luaci:20210916-115155-f4045b
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - run: |
+          luacheck .
+      - run: |
+          stylua --check .

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # nvim-magic
 
+![ci](https://github.com/jameshiew/nvim-magic/actions/workflows/ci.yml/badge.svg)
 [![Pipeline Status](https://gitlab.com/jameshiew/nvim-magic/badges/master/pipeline.svg)](https://gitlab.com/jameshiew/nvim-magic/-/pipelines)
 
 A pluggable framework for integrating AI code assistance into Neovim. The goals are to make using AI code assistance unobtrusive, and to make it easy to create and share new flows that use AI code assistance. Go to [quickstart](#quickstart) for how to install. It currently works with [OpenAI Codex](https://openai.com/blog/openai-codex/).


### PR DESCRIPTION
The stylua check is disabled on gitlab, apparently because it hangs
permanently. However, using GitHub Actions with the same container
doesn't seem to have any such problem. Since this is a public
repository, using GitHub Actions is free and now we can run both CI
tools.
