### PR TITLE
refactor(ui): use win_options for number

### DIFF
--- a/lua/nvim-magic/_ui.lua
+++ b/lua/nvim-magic/_ui.lua
@@ -29,9 +29,11 @@ function ui.pop_up(lines, filetype, border_text, keymaps)
 			filetype = filetype,
 			buftype = 'nofile',
 		},
+		win_options = {
+			number = true,
+		},
 	})
 	popup:mount()
-	vim.cmd([[set number]]) -- for some reason, using number=true in buf_options doesn't work so we do this instead
 	popup:on(event.BufLeave, function()
 		popup:unmount()
 	end)


### PR DESCRIPTION
Just noticed the comment saying "using number=true in buf_options doesn't work".

So, it was not working because `'number'` option is actually local to window.

![image](https://user-images.githubusercontent.com/8050659/142777375-dc52d49a-bee0-43f3-862d-d00d524e0523.png)

Using `win_options` would solve it.